### PR TITLE
Fix _target location

### DIFF
--- a/portshaker.sh.in
+++ b/portshaker.sh.in
@@ -141,11 +141,7 @@ if [ "${_do_merge}" -eq 1 ]; then
 		fi
 
 		if [ -n "${_poudriere_tree}" ]; then
-			if [ $_use_zfs -eq 1 ]; then
-				_target="${poudriere_ports_mountpoint}/${_poudriere_tree}/ports"
-			else
-				_target="${poudriere_ports_mountpoint}/${_poudriere_tree}"
-			fi
+			_target="${poudriere_ports_mountpoint}/${_poudriere_tree}"
 		fi
 
 		if [ -z "${_target}" ]; then


### PR DESCRIPTION
The _target is incorrect, So I revert "Modernize poudriere ports tree locations."
and changes _target by removing "/ports". So we can set any _target we
want, The location no longer have limitation that ends with "ports" when using
ZFS.