### PR TITLE
New method: svn+subtrees.

### DIFF
--- a/examples/portshaker.d/freebsd_subset.in
+++ b/examples/portshaker.d/freebsd_subset.in
@@ -1,0 +1,18 @@
+#!/bin/sh
+# $Id$
+
+. @@PREFIX@@/share/portshaker/portshaker.subr
+
+if [ "$1" != '--' ]; then
+	err 1 "Extra arguments"
+fi
+shift
+
+method="svn"
+svn_checkout_path="svn://svn.freebsd.org/ports/head"
+svn_checkout_subtrees="
+  emulators/mame
+  net/samba34@319916
+"
+
+run_portshaker_command $*

--- a/portshaker.d.5.in
+++ b/portshaker.d.5.in
@@ -49,9 +49,10 @@ Update method. Should be one of
 .Va git ,
 .Va hg
 (mercurial),
-.Va rsync
+.Va rsync ,
+.Va svn ,
 or
-.Va svn .
+.Va svn+subtrees .
 .It Ar csup_supfile
 .Pq Vt str
 supfile to provide to
@@ -91,7 +92,17 @@ when
 .It Ar svn_checkout_path
 .Pq Vt str
 URI to checkout the ports tree from when
-.Dq Ar method Ns Li = Ns Vt svn .
+.Dq Ar method Ns Li = Ns Vt svn
+or
+.Dq Ar method Ns Li = Ns Vt svn+subtrees .
+.It Ar svn_checkout_subtrees
+.Pq Vt str
+Whitespace separated list of subdirectories
+.Ar path[@rev]
+beneath the
+.Ar svn_checkout_path
+which will be checked out when
+.Dq Ar method Ns Li = Ns Vt svn+subtrees .
 .El
 .Ss Special consideration when Dq Ar method Ns Li = Ns Vt csup
 When updating a
@@ -137,6 +148,23 @@ shell script containing:
 \&. @@PREFIX@@/share/portshaker/portshaker.subr
 method="svn"
 svn_checkout_path="http://bsd-sharp.googlecode.com/svn/trunk/"
+run_portshaker_command $*
+.Ed
+.Pp
+If you want only a subset of ports from the (huge) FreeBSD tree as a
+.Ar source
+ports tree (probably to merge with some other tree), create a
+.Ar @@PREFIX@@/etc/portshaker.d/freebsd_subset
+shell script containing:
+.Bd -literal
+#!/bin/sh
+\&. @@PREFIX@@/share/portshaker/portshaker.subr
+method="svn+subtrees"
+svn_checkout_path="svn://svn.freebsd.org/ports/head"
+svn_checkout_subtrees="
+  emulators/mame
+  net/samba34@319916
+"
 run_portshaker_command $*
 .Ed
 .Pp

--- a/portshaker.subr.in
+++ b/portshaker.subr.in
@@ -33,6 +33,8 @@ RSYNC=${RSYNC:=rsync}
 RSYNC_FLAGS=""
 SVN="${SVN:=svn}"
 #SVN_FLAGS=""
+SVNADMIN="${SVNADMIN:=svnadmin}"
+#SVNADMIN_FLAGS=""
 VCS_ID_KEYWORDS="${VCS_ID_KEYWORDS:=FreeBSD Id MCom}"
 
 # Tinderbox related variables
@@ -1001,6 +1003,49 @@ run_portshaker_command()
 					if [ $? -ne 0 ]; then
 						err 1 "Subversion update failed."
 					fi
+				fi
+				;;
+			svn+subtrees)
+				if [ -z "${svn_checkout_path}" ]; then
+					err 1 "\$svn_checkout_path is not defined."
+				fi
+				cd "${_portsdir}"
+				if [ ! -d "${_portsdir}/.svn" ]; then
+					debug "Running '${SVNADMIN} ${SVNADMIN_FLAGS} create \"${_portsdir}/.repos\"'."
+					${SVNADMIN} ${SVNADMIN_FLAGS} create "${_portsdir}/.repos"
+					if [ $? -ne 0 ]; then
+						err 1 "Creating subversion repository failed."
+					fi
+					debug "Running '${SVN} ${SVN_FLAGS} checkout \"file://${_portsdir}/.repos\" \"${_portsdir}\"'."
+					${SVN} ${SVN_FLAGS} checkout "file://${_portsdir}/.repos" "${_portsdir}"
+					if [ $? -ne 0 ]; then
+						err 1 "Subversion update failed."
+					fi
+					debug "Moving \"${_portsdir}/.repos\" to \"${_portsdir}/.svn/.repos\"."
+					mv "${_portsdir}/.repos" "${_portsdir}/.svn"
+					debug "Running '${SVN} ${SVN_FLAGS} relocate \"file://${_portsdir}/.repos\" \"file://${_portsdir}/.svn/.repos\"'."
+					${SVN} ${SVN_FLAGS} relocate "file://${_portsdir}/.repos" "file://${_portsdir}/.svn/.repos"
+					if [ $? -ne 0 ]; then
+						err 1 "Subversion relocate failed."
+					fi
+				fi
+
+				debug "Running '${SVN} ${SVN_FLAGS} propset svn:externals'."
+				for _part in ${svn_checkout_subtrees}; do
+					echo ${svn_checkout_path}/${_part} $(echo ${_part} | grep -oE '^[^@]+')
+				done | ${SVN} ${SVN_FLAGS} propset svn:externals -F - .
+				if [ $? -ne 0 ]; then
+					err 1 "Subversion propset failed."
+				fi
+				debug "Running '${SVN} ${SVN_FLAGS} commit'."
+				${SVN} ${SVN_FLAGS} commit -m "portshaker: change svn:externals"
+				if [ $? -ne 0 ]; then
+					err 1 "Subversion commit failed."
+				fi
+				debug "Running '${SVN} ${SVN_FLAGS} update'."
+				${SVN} ${SVN_FLAGS} update
+				if [ $? -ne 0 ]; then
+					err 1 "Subversion update failed."
 				fi
 				;;
 			*)


### PR DESCRIPTION
Hi there!

For a bunch of servers I'm building packages bases on a FreeBSD quarterly ports branch. Especially fixes for security issues are sometimes introduced to the branch much too slow for my liking. So I'd like to be able to merge a select few ports from FreeBSD ports head on top of the branch.

This commit implements a new method to make this easy to deal with. It creates a local repository in ${portsdir}/.svn/.repos and uses svn:externals to pull in multiple subtrees of the base ${svn_checkout_path}.