### PR TITLE
add support for merging in new/local port categories

### DIFF
--- a/portshaker.subr.in
+++ b/portshaker.subr.in
@@ -601,6 +601,20 @@ run_portshaker_command()
 
 					debug "Processing ${_category}/${_port}."
 
+					# If this is a new category was merged in, create a stub Makefile for it if necessary
+					if [ ! -f "${_target}/${_category}/Makefile" ]; then
+						debug "creating stub Makefile for category ${_category}."
+						{
+							echo '# $FreeBSD'
+							echo '#'
+							echo ""
+							echo "    COMMENT = ${_category} ports"
+							echo ""
+							echo ""
+							echo ".include <bsd.port.subdir.mk>"
+						} > "${_target}/${_category}/Makefile"
+					fi
+
 					if [ ! -f "${_port}/Makefile" ]; then
 						warn "${_category}/${_port}: No Makefile in this directory!"
 						continue


### PR DESCRIPTION
If merging in a ports tree that contains new port categories (e.g.:
local), portshaker now will create a stub Makefile for the new category
if necessary.  Without this change, portshaker emits the following
warning while updating the category Makefile:

[Debug 11:52:43] Updating local Makefile.
head: Makefile: No such file or directory
tail: Makefile: No such file or directory

And the category Makefile is not valid (it only contains SUBDIR +=
lines).  This patch fixes both problems.