### PR TITLE
Local categories

### DIFF
--- a/portshaker.subr.in
+++ b/portshaker.subr.in
@@ -592,6 +592,12 @@ run_portshaker_command()
 					continue
 				fi
 				cd ${_category} || exit 1
+
+				if [ ! -d "${_target}/${_category}" ]; then
+					debug "creating new category: ${_category}"
+					mkdir "${_target}/${_category}" || exit 1
+				fi
+
 				for _port in `ls`; do
 					if [ ${_port} = "CVS" -o ${_port} = ".svn" ]; then
 						continue
@@ -601,7 +607,8 @@ run_portshaker_command()
 
 					debug "Processing ${_category}/${_port}."
 
-					# If this is a new category was merged in, create a stub Makefile for it if necessary
+					# if there is no Makefile in this category (its a new
+					# category), then create a stub Makefile
 					if [ ! -f "${_target}/${_category}/Makefile" ]; then
 						debug "creating stub Makefile for category ${_category}."
 						{

--- a/portshaker.subr.in
+++ b/portshaker.subr.in
@@ -601,6 +601,20 @@ run_portshaker_command()
 
 					debug "Processing ${_category}/${_port}."
 
+					# If this is a new category was merged in, create a stub Makefile for it if necessary
+					if [ ! -f "${_target}/${_category}/Makefile" ]; then
+						debug "creating stub Makefile for category ${_category}."
+						{
+							echo '# $FreeBSD'
+							echo '#'
+							echo ""
+							echo "    COMMENT = ${_category} ports"
+							echo ""
+							echo ""
+							echo ".include <bsd.port.subdir.mk>"
+						} > "${_target}/${_category}/Makefile"
+					fi
+
 					if [ ! -f "${_port}/Makefile" ]; then
 						warn "${_category}/${_port}: No Makefile in this directory!"
 						continue


### PR DESCRIPTION
this pull request adds support for merging custom port categories into the ports tree.

If portshaker encounters a new category, it will make the category directory in the target ports tree.  It will now auto-generate a stub category Makefile if necessary as well.  This allows merging of ports trees that have "local" or other custom category names.