### PR TITLE
Handle comments in Makefiles

### DIFF
--- a/portshaker.subr.in
+++ b/portshaker.subr.in
@@ -178,7 +178,7 @@ portshaker_usage()
 # 	$1 - Name of the variable to read.
 read_makefile_value()
 {
-	value=`awk 'BEGIN { r = ""} /^'$1'\??=/ { split($0, a, /=[[:space:]]*/); r = a[2]; } END { print r }  ' Makefile`
+	value=`awk 'BEGIN { r = ""} /^'$1'\??=/ { split($0, a, /=[[:space:]]*/); r = a[2]; split(r, b, /[[:space:]]*#/); r = b[1] } END { print r }  ' Makefile`
 	if [ -z "${value}" -o "${value%${value#?}}" = '$' ]; then
 		debug "Can't read variable '$1' from Makefile in '$PWD'.  Falling back to make(1)."
 		value=`make -V $1`


### PR DESCRIPTION
Some ports have comments in uncommon places in their Makefiles.
E.g. mail/spamassassin has a comment for its PORTREVISION which breaks version comparison.

So this should remove comments from all read variables. As this function is only used to read PORTEPOCH, PORTVERSION and PORTREVISION it should be safe to remove these.