### PR TITLE
Fix processing Mk/* subdirectory handling

### DIFF
--- a/portshaker.subr.in
+++ b/portshaker.subr.in
@@ -557,7 +557,7 @@ run_portshaker_command()
 					err 1 "'${_target}/Mk' missing! copy / clone repository before merging."
 				fi
 				cd "${_portsdir}/Mk" || exit 1
-				for _mk in `ls`; do
+				for _mk in `find . -type f | sed s:"./"::`; do
 					if [ ${_mk} = "CVS" -o ${_mk} = ".svn" ]; then
 						continue
 					fi


### PR DESCRIPTION
There are some changes lately to the ports tree, e.g. having an MK/Uses/* directory. The "patch" will then try to patch the whole directory, resulting in 0 byte and .orig files.

The find will now take every single file, thus patching only happends on a per file base