### PR TITLE
add new port category directories if necessary

### DIFF
--- a/portshaker.subr.in
+++ b/portshaker.subr.in
@@ -594,6 +594,10 @@ run_portshaker_command()
 					continue
 				fi
 				cd ${_category} || exit 1
+				if [ ! -d "${_target}/${_category}" ]; then
+					debug "creating new category: ${_category}"
+					mkdir "${_target}/${_category}" || exit 1
++				fi
 				for _port in `ls`; do
 					if [ ${_port} = "CVS" -o ${_port} = ".svn" ]; then
 						continue


### PR DESCRIPTION
If a new port category is being merged in, create the necessary category
directory in the ports tree so that it can be merged in successfully.

This allows merging in new port category dirs that do not exist in the target ports tree.  Without this, "portshaker -M" fails to merge in new categories.