### PR TITLE
Allow portshaker to use a non standard etc directory

### DIFF
--- a/portshaker.subr.in
+++ b/portshaker.subr.in
@@ -10,8 +10,10 @@ if [ -z "${_portshaker_subr_loaded}" ]; then
 _portshaker_subr_loaded="YES"
 verbose="0"
 
+PORTSHAKER_CONFIG_DIR="${PORTSHAKER_CONFIG_DIR:=@@ETCDIR@@}"
+
 if [ "${_portshaker_load_config}" != "no" ]; then
-	config_dir="@@ETCDIR@@"
+	config_dir="${PORTSHAKER_CONFIG_DIR}"
 	. ${config_dir}/portshaker.conf
 fi
 

--- a/portshaker.subr.in
+++ b/portshaker.subr.in
@@ -10,10 +10,8 @@ if [ -z "${_portshaker_subr_loaded}" ]; then
 _portshaker_subr_loaded="YES"
 verbose="0"
 
-PORTSHAKER_CONFIG_DIR="${PORTSHAKER_CONFIG_DIR:=@@ETCDIR@@}"
-
 if [ "${_portshaker_load_config}" != "no" ]; then
-	config_dir="${PORTSHAKER_CONFIG_DIR}"
+	config_dir="${portshaker_config_dir:=@@ETCDIR@@}"
 	. ${config_dir}/portshaker.conf
 fi
 


### PR DESCRIPTION
portshaker reads portshaker.conf and the contents of portshaker.d/ from
/usr/local/etc by default. Adding an environment variable
PORTSHAKER_CONFIG_DIR allows the user to use a different location for
configuration;

PORTSHARKER_CONFIG_DIR=/var/foo/bar portshaker -U

This is useful when running portshaker in a continuous integration
environment where one wants to keep work isolated from the rest of the
system.