### PR TITLE
Disable filename globbing when performing rsync

### DIFF
--- a/portshaker.subr.in
+++ b/portshaker.subr.in
@@ -1033,10 +1033,13 @@ run_portshaker_command()
 					err 1 "\$rsync_source_path is not defined."
 				fi
 				debug "Running '${RSYNC} ${RSYNC_FLAGS} ${RSYNC_ARGS} ${rsync_extra_args} ${rsync_source_path}/ ${_portsdir}/'."
+				set -f
 				${RSYNC} ${RSYNC_FLAGS} ${RSYNC_ARGS} ${rsync_extra_args} "${rsync_source_path}/" "${_portsdir}/"
 				if [ $? -ne 0 ]; then
+					set +f
 					err 1 "rsync update failed."
 				fi
+				set +f
 				;;
 			svn)
 				if [ -z "${svn_checkout_path}" ]; then

--- a/portshaker.subr.in
+++ b/portshaker.subr.in
@@ -1035,11 +1035,11 @@ run_portshaker_command()
 				debug "Running '${RSYNC} ${RSYNC_FLAGS} ${RSYNC_ARGS} ${rsync_extra_args} ${rsync_source_path}/ ${_portsdir}/'."
 				set -f
 				${RSYNC} ${RSYNC_FLAGS} ${RSYNC_ARGS} ${rsync_extra_args} "${rsync_source_path}/" "${_portsdir}/"
-				if [ $? -ne 0 ]; then
-					set +f
+				rsync_res=$?
+				set +f
+				if [ $rsync_res -ne 0 ]; then
 					err 1 "rsync update failed."
 				fi
-				set +f
 				;;
 			svn)
 				if [ -z "${svn_checkout_path}" ]; then


### PR DESCRIPTION
It's very hard to correctly specify includes + excludes in the
portshaker.d rsync_extra_args without this.