### PR TITLE
Fix build on FreeBSD 12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,8 @@ MAN5=		portshaker.conf.5 portshaker.d.5
 MAN8=		portshaker.8
 
 FILES=		merge-updating.awk portshaker.conf.sample portshaker.subr
-FILESDIR_merge-updating.awk=		${SHAREDIR}/portshaker
+FILESDIR=	${SHAREDIR}/portshaker
 FILESDIR_portshaker.conf.sample=	${ETCDIR}
-FILESDIR_portshaker.subr=		${SHAREDIR}/portshaker
 
 DISTDIR=	portshaker-${VERSION}
 TARBALL=	${DISTDIR}.tar.gz


### PR DESCRIPTION
Portshaker currently doesn't build on FreeBSD 12, this PR fixes the build on FreeBSD 12.

Upstream issue: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=233053