### PR TITLE
Fix argument passing and parsing

### DIFF
--- a/examples/portshaker.d/enlightenment.in
+++ b/examples/portshaker.d/enlightenment.in
@@ -11,4 +11,4 @@ shift
 method="svn"
 svn_checkout_path="http://subversion.assembla.com/svn/e17-ports/trunk"
 
-run_portshaker_command $*
+run_portshaker_command "$@"

--- a/examples/portshaker.d/freebsd_subset.in
+++ b/examples/portshaker.d/freebsd_subset.in
@@ -15,4 +15,4 @@ svn_checkout_subtrees="
   net/samba34@319916
 "
 
-run_portshaker_command $*
+run_portshaker_command "$@"

--- a/examples/portshaker.d/gecko.in
+++ b/examples/portshaker.d/gecko.in
@@ -11,4 +11,4 @@ shift
 method="svn"
 svn_checkout_path="https://trillian.chruetertee.ch/svn/freebsd-gecko/trunk/"
 
-run_portshaker_command $*
+run_portshaker_command "$@"

--- a/examples/portshaker.d/github.in
+++ b/examples/portshaker.d/github.in
@@ -23,5 +23,4 @@ method="git"
 git_clone_uri="https://github.com/${username}/${project}"
 git_branch=${git_branch:=master}
 
-run_portshaker_command $*
-
+run_portshaker_command "$@"

--- a/examples/portshaker.d/haskell.in
+++ b/examples/portshaker.d/haskell.in
@@ -11,4 +11,4 @@ shift
 method="git"
 git_clone_uri="git://github.com/freebsd-haskell/freebsd-haskell.git"
 
-run_portshaker_command $*
+run_portshaker_command "$@"

--- a/examples/portshaker.d/marcuscom_ports.in
+++ b/examples/portshaker.d/marcuscom_ports.in
@@ -20,4 +20,4 @@ marcuscom_ports_postmerge_to()
     warn "a look to the marcus-merge(8) script."
 }
 
-run_portshaker_command $*
+run_portshaker_command "$@"

--- a/examples/portshaker.d/marcuscom_ports_stable.in
+++ b/examples/portshaker.d/marcuscom_ports_stable.in
@@ -11,4 +11,4 @@ shift
 method="svn"
 svn_checkout_path="svn://creme-brulee.marcuscom.com/ports-stable/trunk"
 
-run_portshaker_command $*
+run_portshaker_command "$@"

--- a/examples/portshaker.d/ports.in
+++ b/examples/portshaker.d/ports.in
@@ -15,4 +15,4 @@ method="portsnap"
 #method="csup"
 #csup_supfile="@@PREFIX@@/etc/portshaker.d/ports-supfile"
 
-run_portshaker_command $*
+run_portshaker_command "$@"

--- a/examples/portshaker.d/redports.in
+++ b/examples/portshaker.d/redports.in
@@ -16,4 +16,4 @@ shift
 method="svn"
 svn_checkout_path="http://svn.redports.org/${username}"
 
-run_portshaker_command $*
+run_portshaker_command "$@"

--- a/examples/portshaker.d/xorg.in
+++ b/examples/portshaker.d/xorg.in
@@ -11,4 +11,4 @@ shift
 method="svn"
 svn_checkout_path="https://trillian.chruetertee.ch/svn/ports/trunk/"
 
-run_portshaker_command $*
+run_portshaker_command "$@"

--- a/portshaker.d.5.in
+++ b/portshaker.d.5.in
@@ -152,7 +152,7 @@ if [ "$1" != '--' ]; then
 fi
 shift
 method="portsnap"
-run_portshaker_command $*
+run_portshaker_command "$@"
 .Ed
 .Pp
 To configure the BSD# ports tree as a
@@ -169,7 +169,7 @@ fi
 shift
 method="svn"
 svn_checkout_path="http://bsd-sharp.googlecode.com/svn/trunk/"
-run_portshaker_command $*
+run_portshaker_command "$@"
 .Ed
 .Pp
 If you want only a subset of ports from the (huge) FreeBSD tree as a
@@ -190,7 +190,7 @@ svn_checkout_subtrees="
   emulators/mame
   net/samba34@319916
 "
-run_portshaker_command $*
+run_portshaker_command "$@"
 .Ed
 .Pp
 To setup a dynamic redports
@@ -210,7 +210,7 @@ extra_info=":${username}"
 shift
 method="svn"
 svn_checkout_path="http://svn.redports.org/${username}"
-run_portshaker_command $*
+run_portshaker_command "$@"
 .Ed
 .Pp
 You can then specify the
@@ -243,7 +243,7 @@ git_clone_uri="git@github.com:freebsd/freebsd-ports.git"
 git_branch="master"
 git_submodules="yes"
 git_submodules_branch="development"
-run_portshaker_command $*
+run_portshaker_command "$@"
 .Sh SEE ALSO
 .Xr csup 1 ,
 .Xr portshaker 8 ,

--- a/portshaker.subr.in
+++ b/portshaker.subr.in
@@ -357,9 +357,8 @@ run_portshaker_command()
 
 	_portshaker_arg=$1
 	shift 1
-	_portshaker_extra_args="$*"
 
-	debug "${_portshaker_arg} ${_portshaker_extra_args}"
+	debug "${_portshaker_arg} $*"
 
 	# if ${extra_info} contains `:`, the port infrastructure will produce
 	# warnings when attempting to launch make(1) from the source directory
@@ -389,7 +388,7 @@ run_portshaker_command()
 		# Look for a pre-command and execute it.
 		if type ${name}_pre${_portshaker_arg} 1>/dev/null 2>&1; then
 			info "Executing pre-command '${name}_pre${_portshaker_arg}'."
-			${name}_pre${_portshaker_arg} ${_portshaker_extra_args} || exit 1
+			${name}_pre${_portshaker_arg} "$@" || exit 1
 		fi
 
 		if [ $_use_zfs -eq 1 ]; then
@@ -399,29 +398,16 @@ run_portshaker_command()
 		# Proceed with the command
 		case "${_portshaker_arg}" in
 		clone_to|copy_to)
-			_args=`getopt aP:pt:z: ${_portshaker_extra_args}`
-			if [ $? -ne 0 ]; then
-				portshaker_usage
-			fi
-			set -- ${_args}
 			_target=""
 			_zfs_target_dataset=""
-			for _i; do
+			set -- "$@"
+			while getopts aP:pt:z: _i; do
 				case "${_i}" in
-					-p)
-						_pretend=1
-						shift ;;
-					-P)
-						_poudriere_tree="$2"; shift
-						shift ;;
-					-t)
-						_target="$2"; shift
-						shift ;;
-					-z)
-						_zfs_target_dataset="$2"; shift
-						shift ;;
-					--)
-						shift; break ;;
+					p) _pretend=1 ;;
+					P) _poudriere_tree="$OPTARG" ;;
+					t) _target="$OPTARG" ;;
+					z) _zfs_target_dataset="$OPTARG" ;;
+					?) portshaker_usage ;;
 				esac
 			done
 			if [ -z "${_target}" ]; then
@@ -520,34 +506,19 @@ run_portshaker_command()
 			esac
 			;;
 		merge_to)
-			_args=`getopt ab:m:pt: ${_portshaker_extra_args}`
-			if [ $? -ne 0 ]; then
-				portshaker_usage
-			fi
-			set -- ${_args}
 			_auto_install=0
 			_master=""
 			_target=""
 			_tinderbox_builds=""
-			for _i; do
+			set -- "$@"
+			while getopts ab:m:pt: _i; do
 				case "${_i}" in
-					-a)
-						_auto_install=1
-						shift ;;
-					-b)
-						_tinderbox_builds="${_tinderbox_builds} $2"; shift
-						shift ;;
-					-m)
-						_master="$2"; shift
-						shift ;;
-					-p)
-						_pretend=1
-						shift ;;
-					-t)
-						_target="$2"; shift
-						shift ;;
-					--)
-						shift; break ;;
+					a) _auto_install=1 ;;
+					b) _tinderbox_builds="${_tinderbox_builds} $OPTARG" ;;
+					m) _master="$OPTARG" ;;
+					p) _pretend=1 ;;
+					t) _target="$OPTARG" ;;
+					?) portshaker_usage ;;
 				esac
 			done
 			if [ -z "${_master}" -o -z "${_target}" ]; then
@@ -1150,7 +1121,7 @@ run_portshaker_command()
 		# Look for a post-command and execute it
 		if type ${name}_post${_portshaker_arg} 1>/dev/null 2>&1; then
 			info "Executing post-command \"${name}_post${_portshaker_arg}\"."
-			${name}_post${_portshaker_arg} ${_portshaker_extra_args} || exit 1
+			${name}_post${_portshaker_arg} "$@" || exit 1
 		fi
 
 		return ${_return}


### PR DESCRIPTION
Yesterday I tried switching my static source definitions to dynamic ones since I'm always using quarterly-branch based ports trees anyways and though I could avoid having to do the copy-and-edit dance in `portshaker.d` every quarter.

Pulling and updating from these definitions (that's: FreeBSD official quarterly ports from `svn`, overlay from FreeBSD ports head per `svn+subtrees` and personal additions from a `git` branch) work well, but merging fails. Here's my (possible incomplete) understanding what happens:

1. Portshaker iterates over all words in the `[...]_merge_from` variable for the merge destination (loop starting [line 161](https://github.com/smortex/portshaker/blob/c0e77bbb8240cfa23a2f4708d53c85787a316965/portshaker.sh.in#L161)) and right away replaces colons with spaces in the current word ([line 164](https://github.com/smortex/portshaker/blob/c0e77bbb8240cfa23a2f4708d53c85787a316965/portshaker.sh.in#L164)). That result later on get's saved as the variable `_master` for the next iteration ([line 208](https://github.com/smortex/portshaker/blob/c0e77bbb8240cfa23a2f4708d53c85787a316965/portshaker.sh.in#L208)) and that again is used to call the source definition script in `merge_to` mode ([line 211](https://github.com/smortex/portshaker/blob/c0e77bbb8240cfa23a2f4708d53c85787a316965/portshaker.sh.in#L211)). Note that at this place quoting is still correct: `-m "${_master}"`.
2. All examples of source definition scripts will end with the line `run_portshaker_command $*`. Even the one demonstrating the dynamic mode will do this: [examples/portshaker.d/redports.in](https://github.com/smortex/portshaker/blob/c0e77bbb8240cfa23a2f4708d53c85787a316965/examples/portshaker.d/redports.in#L19). Using unquoted `$*` here will loose the correct quoting of the argument to `-m`.

    The only way to correctly pass quoted arguments to a function in a POSIX shell (such as FreeBSD `/bin/sh`) I know of is using `"$@"`. Try the example [`print_three.sh`](https://gist.github.com/wagnerflo/fac13e7683787e2afbdba036f35aeff6) to see the differences.
3. But even if I write my source definition scripts with `run_portshaker_command "$@"` the implementation of this function still messes up. After shifting off the mode it saves `$*` in the variable `_portshaker_extra_args` ([line 360](https://github.com/smortex/portshaker/blob/c0e77bbb8240cfa23a2f4708d53c85787a316965/portshaker.subr.in#L360)). This right here looses the quotes. But even if you'd replace it with `portshaker_extra_args="$@"` it'll not work since there's no way to, later of, expand this normal variable the same way as `"$@"` (the special expansion mode "keeping quoted words intact" is only available for `"$@"`; see `man 1 sh` heading "Special Parameter").
4. And the last problem in this chain is that apparently `getopt(1)` can't handle quoted parameters arguments at all. Here again is a gist demonstrating this: [`getopt.sh`](https://gist.github.com/wagnerflo/89f94a6073e36040a5c43d4d837a4ae8). Even if you feed it with `"$@"` (or alternatively just directly with `-m "abc def"`) it'll break up the quoted arguments. Sure you could reassemble them in the loop, but why not just use the shell builtin `getopts` which doesn't have this problem?

This pull request fixes all these problems, should not break anything else (no matter if static or dynamic source definition and no matter with you use `$*` or `"$@"` to call `run_portshaker_command` there). I also modified the examples and the man page to always use `run_portshaker_command "$@"` for consistency.