### PR TITLE
Fix re-generation of categories Makefiles

### DIFF
--- a/portshaker.subr.in
+++ b/portshaker.subr.in
@@ -802,9 +802,9 @@ run_portshaker_command()
 					(cd ${_target}/${_category}
 					debug "Updating ${_category} Makefile."
 					if [ ${_pretend} -eq 0 ]; then
-						head -n 5 Makefile > Makefile.new
+						sed -e '/SUBDIR/,$d' Makefile > Makefile.new
 						find . -mindepth 1 -maxdepth 1 -type d -print | sort | sed -e 's|^./|    SUBDIR += |' >> Makefile.new
-						tail -n 2 Makefile >> Makefile.new
+						sed -e '1,/SUBDIR/d' -e '/SUBDIR/d' Makefile >> Makefile.new
 						mv -f Makefile.new Makefile
 					fi
 					)


### PR DESCRIPTION
With the transition to git, some comments where removed from the
categories Makefiles ($FreeBSD$).  Because we copied the 5 first lines
verbatim, we copied two much lines which leads to unexpected duplicates.

Remove lines by filtering the ones featuring SUBDIR to avoid this issue.

This issue was reported by @tuaris here:
https://github.com/freebsd/poudriere/issues/856