### PR TITLE
Fix bug when using branches in sources

### DIFF
--- a/portshaker.sh.in
+++ b/portshaker.sh.in
@@ -208,7 +208,8 @@ if [ "${_do_merge}" -eq 1 ]; then
 				_master="${_source}"
 				_first=0
 			else
-				${config_dir}/portshaker.d/${_source} -- merge_to ${_merge_flags} -m "${_master}" -t ${_target} || exit 1
+				_master=`echo ${_master} | sed 's/ /_/g'`
+    				${config_dir}/portshaker.d/${_source} -- merge_to ${_merge_flags} -m "${_master}" -t ${_target} || exit 1
 			fi
 		done
 


### PR DESCRIPTION
I think you need to replace spaces with "_".  Otherwise Portshaker gets confused when you use Git branches in some sources, and tries to call the `merge_to` sub command like:

```
merge_to -m source branch -t /usr/local/poudriere/ports/target
```